### PR TITLE
feat: initial annuaire platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+.env
+backend/.venv/
+backend/data/
+frontend/node_modules/
+frontend/dist/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,50 @@
-# generateur-insee
+# Générateur d'annuaires métiers
+
+Cette plateforme propose un backend FastAPI et un frontend React permettant de créer des annuaires métiers alimentés par l'API SIRENE. Elle inclut :
+
+- un back-office pour configurer les filtres SIRENE, les prompts OpenAI et les pages manuelles ;
+- un importeur respectant la pagination par curseur de l'API SIRENE (V3), avec prise en compte des établissements fermés ;
+- une génération de contenu via OpenAI configurable par template ;
+- un géocodage des adresses via la Base Adresse Nationale pour l'affichage sur carte.
+
+## Démarrage rapide
+
+### Backend
+
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+uvicorn app.main:app --reload
+```
+
+Les variables d'environnement peuvent être définies dans un fichier `.env` à la racine du backend :
+
+```env
+GENERATEUR_DATABASE_URL=sqlite:///./data/app.db
+GENERATEUR_SIRENE_API_KEY=votre_cle_api
+GENERATEUR_OPENAI_API_KEY=votre_cle_openai
+```
+
+### Frontend
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Par défaut, le proxy Vite redirige les appels `/api` vers `http://localhost:8000`.
+
+## Fonctionnalités clés
+
+- **Gestion des sites** : création de sites d'annuaires avec filtres SIRENE personnalisés.
+- **Pages manuelles** : éditeur simple permettant d'ajouter des contenus enrichis.
+- **Imports SIRENE** : création de tâches d'import respectant les limites (30 requêtes/minute, 1000 résultats/page) et suivi des fermetures.
+- **Génération OpenAI** : prompts configurables par site avec test de rendu.
+- **Géocodage BAN** : géocodage différé des adresses et visualisation Leaflet des établissements.
+
+## Tests
+
+Des tests peuvent être ajoutés via `pytest` côté backend et les outils React Testing Library côté frontend.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,30 @@
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    database_url: str = Field(
+        default="sqlite:///./data/app.db",
+        description="URL de connexion à la base de données",
+    )
+    sirene_base_url: str = Field(
+        default="https://api.insee.fr/entreprises/sirene/V3",
+        description="Endpoint racine de l'API SIRENE",
+    )
+    sirene_api_key: str | None = Field(
+        default=None, description="Clé API SIRENE ou token OAuth"
+    )
+    sirene_oauth_client_id: str | None = None
+    sirene_oauth_client_secret: str | None = None
+    sirene_rate_limit_per_minute: int = 30
+    sirene_default_page_size: int = 1000
+    openai_api_key: str | None = None
+    ban_base_url: str = "https://api-adresse.data.gouv.fr"
+
+    class Config:
+        env_file = ".env"
+        env_prefix = "GENERATEUR_"
+
+
+def get_settings() -> Settings:
+    return Settings()

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,18 @@
+from contextlib import contextmanager
+from sqlmodel import Session, SQLModel, create_engine
+
+from .config import get_settings
+
+
+settings = get_settings()
+engine = create_engine(settings.database_url, echo=False, connect_args={"check_same_thread": False} if settings.database_url.startswith("sqlite") else {})
+
+
+def init_db() -> None:
+    SQLModel.metadata.create_all(engine)
+
+
+@contextmanager
+def get_session() -> Session:
+    with Session(engine) as session:
+        yield session

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -1,0 +1,17 @@
+from contextlib import contextmanager
+from typing import Iterator
+
+from sqlmodel import Session
+
+from .database import get_session as _get_session
+
+
+@contextmanager
+def session_scope() -> Iterator[Session]:
+    with _get_session() as session:
+        yield session
+
+
+def get_db_session() -> Session:
+    with _get_session() as session:
+        yield session

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,29 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from .database import init_db
+from .routers import establishments, generation, imports, pages, prompts, sites
+
+init_db()
+
+app = FastAPI(title="Générateur d'annuaires métiers")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(sites.router)
+app.include_router(pages.router)
+app.include_router(imports.router)
+app.include_router(establishments.router)
+app.include_router(prompts.router)
+app.include_router(generation.router)
+
+
+@app.get("/")
+def root() -> dict[str, str]:
+    return {"message": "API de génération d'annuaires métiers opérationnelle"}

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+
+from sqlalchemy import JSON, Column
+from sqlmodel import Field, Relationship, SQLModel
+
+
+class Site(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    slug: str = Field(index=True, sa_column_kwargs={"unique": True})
+    description: Optional[str] = None
+    sirene_filters: dict[str, str] | None = Field(
+        default=None, sa_column=Column(JSON, nullable=True)
+    )
+    openai_prompt: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+    pages: list["ManualPage"] = Relationship(back_populates="site")
+    establishments: list["Establishment"] = Relationship(back_populates="site")
+
+
+class ManualPage(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    site_id: int = Field(foreign_key="site.id")
+    title: str
+    slug: str = Field(index=True)
+    content: str
+    seo_description: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+    site: "Site" = Relationship(back_populates="pages")
+
+
+class Establishment(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    site_id: int = Field(foreign_key="site.id", index=True)
+    siren: str = Field(index=True)
+    nic: str = Field(index=True)
+    siret: str = Field(index=True, sa_column_kwargs={"unique": True})
+    business_name: Optional[str] = None
+    naf_code: Optional[str] = Field(default=None, index=True)
+    naf_label: Optional[str] = None
+    address: Optional[str] = None
+    postal_code: Optional[str] = Field(default=None, index=True)
+    city: Optional[str] = Field(default=None, index=True)
+    department: Optional[str] = Field(default=None, index=True)
+    is_active: bool = Field(default=True, index=True)
+    closure_label: Optional[str] = None
+    imported_at: datetime = Field(default_factory=datetime.utcnow)
+    last_seen_at: datetime = Field(default_factory=datetime.utcnow)
+    geo_lat: Optional[float] = Field(default=None, index=True)
+    geo_lon: Optional[float] = Field(default=None, index=True)
+    geo_status: Optional[str] = Field(default=None)
+    extra_metadata: dict[str, Any] | None = Field(
+        default=None, sa_column=Column(JSON, nullable=True)
+    )
+
+    site: "Site" = Relationship(back_populates="establishments")
+
+
+class ImportJob(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    site_id: int = Field(foreign_key="site.id")
+    naf_code: Optional[str] = None
+    department: Optional[str] = None
+    city: Optional[str] = None
+    status: str = Field(default="pending")
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    cursor: Optional[str] = None
+    total_imported: int = 0
+    total_closed: int = 0
+    total_errors: int = 0
+    last_error: Optional[str] = None
+
+
+class PromptTemplate(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    site_id: int = Field(foreign_key="site.id")
+    label: str
+    prompt: str
+    scope: str = Field(default="city", description="city|postal_code|custom")
+    created_at: datetime = Field(default_factory=datetime.utcnow)

--- a/backend/app/routers/__init__.py
+++ b/backend/app/routers/__init__.py
@@ -1,0 +1,10 @@
+from . import establishments, generation, imports, pages, prompts, sites
+
+__all__ = [
+    "establishments",
+    "generation",
+    "imports",
+    "pages",
+    "prompts",
+    "sites",
+]

--- a/backend/app/routers/establishments.py
+++ b/backend/app/routers/establishments.py
@@ -1,0 +1,33 @@
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlmodel import Session, select
+
+from ..dependencies import get_db_session
+from ..models import Establishment, Site
+from ..schemas import EstablishmentRead
+
+router = APIRouter(prefix="/sites/{site_id}/establishments", tags=["establishments"])
+
+
+def _get_site(session: Session, site_id: int) -> Site:
+    site = session.get(Site, site_id)
+    if not site:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Site introuvable")
+    return site
+
+
+@router.get("/", response_model=List[EstablishmentRead])
+def list_establishments(
+    site_id: int,
+    active: Optional[bool] = Query(default=None),
+    postal_code: Optional[str] = Query(default=None),
+    session: Session = Depends(get_db_session),
+) -> List[Establishment]:
+    _get_site(session, site_id)
+    query = select(Establishment).where(Establishment.site_id == site_id)
+    if active is not None:
+        query = query.where(Establishment.is_active == active)
+    if postal_code:
+        query = query.where(Establishment.postal_code == postal_code)
+    return session.exec(query).all()

--- a/backend/app/routers/generation.py
+++ b/backend/app/routers/generation.py
@@ -1,0 +1,35 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlmodel import Session
+
+from ..dependencies import get_db_session
+from ..models import PromptTemplate, Site
+from ..schemas import ContentGenerationRequest, ContentGenerationResponse
+from ..services.generation import ContentGenerationService
+
+router = APIRouter(prefix="/sites/{site_id}/generate", tags=["generation"])
+
+
+def _get_site(session: Session, site_id: int) -> Site:
+    site = session.get(Site, site_id)
+    if not site:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Site introuvable")
+    return site
+
+
+@router.post("/", response_model=ContentGenerationResponse)
+async def generate_content(
+    site_id: int,
+    payload: ContentGenerationRequest,
+    session: Session = Depends(get_db_session),
+) -> ContentGenerationResponse:
+    _get_site(session, site_id)
+    template = session.get(PromptTemplate, payload.template_id)
+    if not template or template.site_id != site_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template introuvable")
+    try:
+        service = ContentGenerationService()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    content = await service.generate_content(payload.template_id, payload.variables, session)
+    prompt = template.prompt.format(**payload.variables)
+    return ContentGenerationResponse(prompt=prompt, content=content)

--- a/backend/app/routers/imports.py
+++ b/backend/app/routers/imports.py
@@ -1,0 +1,58 @@
+import asyncio
+from typing import List
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+from sqlmodel import Session, select
+
+from ..database import get_session
+from ..dependencies import get_db_session
+from ..models import ImportJob, Site
+from ..schemas import ImportJobCreate, ImportJobRead
+from ..services.geocoding import geocode_in_background
+from ..services.sirene import SireneImporter
+
+router = APIRouter(prefix="/sites/{site_id}/imports", tags=["imports"])
+
+
+def _get_site(session: Session, site_id: int) -> Site:
+    site = session.get(Site, site_id)
+    if not site:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Site introuvable")
+    return site
+
+
+@router.get("/", response_model=List[ImportJobRead])
+def list_import_jobs(site_id: int, session: Session = Depends(get_db_session)) -> List[ImportJob]:
+    _get_site(session, site_id)
+    return session.exec(select(ImportJob).where(ImportJob.site_id == site_id)).all()
+
+
+@router.post("/", response_model=ImportJobRead, status_code=status.HTTP_201_CREATED)
+def create_import_job(
+    site_id: int,
+    payload: ImportJobCreate,
+    background_tasks: BackgroundTasks,
+    session: Session = Depends(get_db_session),
+) -> ImportJob:
+    _get_site(session, site_id)
+    job = ImportJob(site_id=site_id, **payload.dict())
+    session.add(job)
+    session.commit()
+    session.refresh(job)
+    background_tasks.add_task(schedule_import_job, job.id)
+    return job
+
+
+def schedule_import_job(job_id: int) -> None:
+    loop = asyncio.get_event_loop()
+    loop.create_task(run_import_job(job_id))
+
+
+async def run_import_job(job_id: int) -> None:
+    importer = SireneImporter()
+    with get_session() as session:
+        job = session.get(ImportJob, job_id)
+        if not job:
+            return
+        await importer.import_for_site(session, job)
+        await geocode_in_background(get_session, job.site_id)

--- a/backend/app/routers/pages.py
+++ b/backend/app/routers/pages.py
@@ -1,0 +1,74 @@
+from datetime import datetime
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlmodel import Session, select
+
+from ..dependencies import get_db_session
+from ..models import ManualPage, Site
+from ..schemas import ManualPageCreate, ManualPageRead, ManualPageUpdate
+
+router = APIRouter(prefix="/sites/{site_id}/pages", tags=["pages"])
+
+
+def _get_site(session: Session, site_id: int) -> Site:
+    site = session.get(Site, site_id)
+    if not site:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Site introuvable")
+    return site
+
+
+@router.get("/", response_model=List[ManualPageRead])
+def list_pages(site_id: int, session: Session = Depends(get_db_session)) -> List[ManualPage]:
+    _get_site(session, site_id)
+    return session.exec(select(ManualPage).where(ManualPage.site_id == site_id)).all()
+
+
+@router.post("/", response_model=ManualPageRead, status_code=status.HTTP_201_CREATED)
+def create_page(
+    site_id: int,
+    payload: ManualPageCreate,
+    session: Session = Depends(get_db_session),
+) -> ManualPage:
+    _get_site(session, site_id)
+    page = ManualPage(site_id=site_id, **payload.dict())
+    session.add(page)
+    session.commit()
+    session.refresh(page)
+    return page
+
+
+@router.get("/{page_id}", response_model=ManualPageRead)
+def get_page(site_id: int, page_id: int, session: Session = Depends(get_db_session)) -> ManualPage:
+    page = session.get(ManualPage, page_id)
+    if not page or page.site_id != site_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Page introuvable")
+    return page
+
+
+@router.put("/{page_id}", response_model=ManualPageRead)
+def update_page(
+    site_id: int,
+    page_id: int,
+    payload: ManualPageUpdate,
+    session: Session = Depends(get_db_session),
+) -> ManualPage:
+    page = session.get(ManualPage, page_id)
+    if not page or page.site_id != site_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Page introuvable")
+    for key, value in payload.dict(exclude_unset=True).items():
+        setattr(page, key, value)
+    page.updated_at = datetime.utcnow()
+    session.add(page)
+    session.commit()
+    session.refresh(page)
+    return page
+
+
+@router.delete("/{page_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_page(site_id: int, page_id: int, session: Session = Depends(get_db_session)) -> None:
+    page = session.get(ManualPage, page_id)
+    if not page or page.site_id != site_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Page introuvable")
+    session.delete(page)
+    session.commit()

--- a/backend/app/routers/prompts.py
+++ b/backend/app/routers/prompts.py
@@ -1,0 +1,46 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlmodel import Session, select
+
+from ..dependencies import get_db_session
+from ..models import PromptTemplate, Site
+from ..schemas import PromptTemplateCreate, PromptTemplateRead
+
+router = APIRouter(prefix="/sites/{site_id}/prompts", tags=["prompts"])
+
+
+def _get_site(session: Session, site_id: int) -> Site:
+    site = session.get(Site, site_id)
+    if not site:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Site introuvable")
+    return site
+
+
+@router.get("/", response_model=List[PromptTemplateRead])
+def list_prompts(site_id: int, session: Session = Depends(get_db_session)) -> List[PromptTemplate]:
+    _get_site(session, site_id)
+    return session.exec(select(PromptTemplate).where(PromptTemplate.site_id == site_id)).all()
+
+
+@router.post("/", response_model=PromptTemplateRead, status_code=status.HTTP_201_CREATED)
+def create_prompt(
+    site_id: int,
+    payload: PromptTemplateCreate,
+    session: Session = Depends(get_db_session),
+) -> PromptTemplate:
+    _get_site(session, site_id)
+    prompt = PromptTemplate(site_id=site_id, **payload.dict())
+    session.add(prompt)
+    session.commit()
+    session.refresh(prompt)
+    return prompt
+
+
+@router.delete("/{prompt_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_prompt(site_id: int, prompt_id: int, session: Session = Depends(get_db_session)) -> None:
+    prompt = session.get(PromptTemplate, prompt_id)
+    if not prompt or prompt.site_id != site_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Prompt introuvable")
+    session.delete(prompt)
+    session.commit()

--- a/backend/app/routers/sites.py
+++ b/backend/app/routers/sites.py
@@ -1,0 +1,54 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlmodel import Session, select
+
+from ..dependencies import get_db_session
+from ..models import Site
+from ..schemas import SiteCreate, SiteRead
+
+router = APIRouter(prefix="/sites", tags=["sites"])
+
+
+@router.get("/", response_model=List[SiteRead])
+def list_sites(session: Session = Depends(get_db_session)) -> List[Site]:
+    return session.exec(select(Site)).all()
+
+
+@router.post("/", response_model=SiteRead, status_code=status.HTTP_201_CREATED)
+def create_site(payload: SiteCreate, session: Session = Depends(get_db_session)) -> Site:
+    site = Site(**payload.dict())
+    session.add(site)
+    session.commit()
+    session.refresh(site)
+    return site
+
+
+@router.get("/{site_id}", response_model=SiteRead)
+def get_site(site_id: int, session: Session = Depends(get_db_session)) -> Site:
+    site = session.get(Site, site_id)
+    if not site:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Site introuvable")
+    return site
+
+
+@router.put("/{site_id}", response_model=SiteRead)
+def update_site(site_id: int, payload: SiteCreate, session: Session = Depends(get_db_session)) -> Site:
+    site = session.get(Site, site_id)
+    if not site:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Site introuvable")
+    for key, value in payload.dict().items():
+        setattr(site, key, value)
+    session.add(site)
+    session.commit()
+    session.refresh(site)
+    return site
+
+
+@router.delete("/{site_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_site(site_id: int, session: Session = Depends(get_db_session)) -> None:
+    site = session.get(Site, site_id)
+    if not site:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Site introuvable")
+    session.delete(site)
+    session.commit()

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,102 @@
+from datetime import datetime
+from typing import Any, Optional
+
+from pydantic import BaseModel
+
+
+class SiteCreate(BaseModel):
+    name: str
+    slug: str
+    description: Optional[str] = None
+    sirene_filters: dict[str, str] | None = None
+    openai_prompt: Optional[str] = None
+
+
+class SiteRead(SiteCreate):
+    id: int
+    created_at: datetime
+
+
+class ManualPageCreate(BaseModel):
+    title: str
+    slug: str
+    content: str
+    seo_description: Optional[str] = None
+
+
+class ManualPageUpdate(BaseModel):
+    title: Optional[str] = None
+    slug: Optional[str] = None
+    content: Optional[str] = None
+    seo_description: Optional[str] = None
+
+
+class ManualPageRead(ManualPageCreate):
+    id: int
+    site_id: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class EstablishmentRead(BaseModel):
+    id: int
+    site_id: int
+    siren: str
+    nic: str
+    siret: str
+    business_name: Optional[str]
+    naf_code: Optional[str]
+    naf_label: Optional[str]
+    address: Optional[str]
+    postal_code: Optional[str]
+    city: Optional[str]
+    department: Optional[str]
+    is_active: bool
+    closure_label: Optional[str]
+    imported_at: datetime
+    last_seen_at: datetime
+    geo_lat: Optional[float]
+    geo_lon: Optional[float]
+    geo_status: Optional[str]
+    extra_metadata: Optional[dict[str, Any]]
+
+
+class ImportJobCreate(BaseModel):
+    naf_code: Optional[str] = None
+    department: Optional[str] = None
+    city: Optional[str] = None
+
+
+class ImportJobRead(ImportJobCreate):
+    id: int
+    site_id: int
+    status: str
+    created_at: datetime
+    updated_at: datetime
+    cursor: Optional[str]
+    total_imported: int
+    total_closed: int
+    total_errors: int
+    last_error: Optional[str]
+
+
+class PromptTemplateCreate(BaseModel):
+    label: str
+    prompt: str
+    scope: str = "city"
+
+
+class PromptTemplateRead(PromptTemplateCreate):
+    id: int
+    site_id: int
+    created_at: datetime
+
+
+class ContentGenerationRequest(BaseModel):
+    template_id: int
+    variables: dict[str, str]
+
+
+class ContentGenerationResponse(BaseModel):
+    prompt: str
+    content: str

--- a/backend/app/services/generation.py
+++ b/backend/app/services/generation.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Any
+
+from openai import AsyncOpenAI
+from sqlmodel import Session
+
+from ..config import Settings, get_settings
+from ..models import PromptTemplate
+
+
+class ContentGenerationService:
+    def __init__(self, settings: Settings | None = None) -> None:
+        self.settings = settings or get_settings()
+        if not self.settings.openai_api_key:
+            raise RuntimeError("Clé OpenAI manquante")
+        self.client = AsyncOpenAI(api_key=self.settings.openai_api_key)
+
+    async def generate_content(self, template_id: int, variables: dict[str, Any], session: Session) -> str:
+        template = session.get(PromptTemplate, template_id)
+        if not template:
+            raise ValueError("Template introuvable")
+        prompt = template.prompt.format(**variables)
+        response = await self.client.responses.create(
+            model="gpt-4.1-mini",
+            input=prompt,
+        )
+        return response.output_text  # type: ignore[return-value]

--- a/backend/app/services/geocoding.py
+++ b/backend/app/services/geocoding.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Optional
+
+import httpx
+from sqlmodel import Session, select
+
+from ..config import Settings, get_settings
+from ..models import Establishment
+
+
+class GeocodingService:
+    def __init__(self, settings: Settings | None = None) -> None:
+        self.settings = settings or get_settings()
+        self._client = httpx.AsyncClient(base_url=self.settings.ban_base_url)
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    async def geocode(self, address: str, city: str | None = None) -> Optional[dict[str, Any]]:
+        params = {"q": address, "limit": 1}
+        if city:
+            params["city"] = city
+        response = await self._client.get("/search/", params=params)
+        response.raise_for_status()
+        data = response.json()
+        features = data.get("features", [])
+        if not features:
+            return None
+        return features[0]
+
+    async def geocode_establishment(self, session: Session, establishment: Establishment) -> None:
+        if not establishment.address:
+            return
+        feature = await self.geocode(establishment.address, establishment.city)
+        if not feature:
+            establishment.geo_status = "not_found"
+        else:
+            geometry = feature.get("geometry", {})
+            coordinates = geometry.get("coordinates", [None, None])
+            establishment.geo_lon = coordinates[0]
+            establishment.geo_lat = coordinates[1]
+            establishment.geo_status = feature.get("properties", {}).get("score")
+        session.add(establishment)
+        session.commit()
+
+    async def geocode_site(self, session: Session, site_id: int, limit: int = 100) -> int:
+        statement = (
+            select(Establishment)
+            .where(Establishment.site_id == site_id)
+            .where(Establishment.geo_lat.is_(None))
+            .where(Establishment.address.is_not(None))
+            .limit(limit)
+        )
+        to_geocode = session.exec(statement).all()
+        count = 0
+        for establishment in to_geocode:
+            await self.geocode_establishment(session, establishment)
+            count += 1
+            await asyncio.sleep(0)  # yield control for cooperative multitasking
+        return count
+
+
+async def geocode_in_background(
+    session_factory,
+    site_id: int,
+    chunk_size: int = 50,
+    delay_seconds: int = 1,
+) -> None:
+    service = GeocodingService()
+    try:
+        while True:
+            with session_factory() as session:
+                processed = await service.geocode_site(session, site_id, limit=chunk_size)
+            if processed == 0:
+                break
+            await asyncio.sleep(delay_seconds)
+    finally:
+        await service.close()

--- a/backend/app/services/sirene.py
+++ b/backend/app/services/sirene.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from datetime import datetime
+from typing import Any, AsyncIterator, Optional
+
+import httpx
+from sqlmodel import Session, select
+from tenacity import RetryError, retry, stop_after_attempt, wait_exponential
+
+from ..config import Settings, get_settings
+from ..models import Establishment, ImportJob, Site
+
+
+class RateLimiter:
+    def __init__(self, limit: int, period_seconds: int = 60) -> None:
+        self.limit = limit
+        self.period = period_seconds
+        self.calls: deque[float] = deque()
+        self._lock = asyncio.Lock()
+
+    async def acquire(self) -> None:
+        async with self._lock:
+            loop = asyncio.get_event_loop()
+            while True:
+                now = loop.time()
+                while self.calls and now - self.calls[0] > self.period:
+                    self.calls.popleft()
+                if len(self.calls) < self.limit:
+                    self.calls.append(loop.time())
+                    return
+                wait_time = self.period - (now - self.calls[0])
+                await asyncio.sleep(max(wait_time, 0))
+
+
+class SireneClient:
+    def __init__(self, settings: Settings | None = None) -> None:
+        self.settings = settings or get_settings()
+        self._token: Optional[str] = None
+        self._client = httpx.AsyncClient(
+            base_url=self.settings.sirene_base_url,
+            timeout=httpx.Timeout(30.0, read=30.0, write=30.0, connect=10.0),
+        )
+        self.rate_limiter = RateLimiter(self.settings.sirene_rate_limit_per_minute)
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    async def _get_auth_headers(self) -> dict[str, str]:
+        if self.settings.sirene_api_key:
+            return {"Authorization": f"Bearer {self.settings.sirene_api_key}"}
+        if self.settings.sirene_oauth_client_id and self.settings.sirene_oauth_client_secret:
+            if not self._token:
+                await self._authenticate()
+            return {"Authorization": f"Bearer {self._token}"}
+        raise RuntimeError("Aucune méthode d'authentification SIRENE configurée")
+
+    async def _authenticate(self) -> None:
+        auth = httpx.BasicAuth(
+            self.settings.sirene_oauth_client_id or "",
+            self.settings.sirene_oauth_client_secret or "",
+        )
+        token_resp = await self._client.post(
+            "https://api.insee.fr/token",
+            data={"grant_type": "client_credentials"},
+            auth=auth,
+        )
+        token_resp.raise_for_status()
+        payload = token_resp.json()
+        self._token = payload["access_token"]
+
+    @retry(wait=wait_exponential(multiplier=1, min=1, max=30), stop=stop_after_attempt(3))
+    async def _get(self, path: str, params: dict[str, Any]) -> httpx.Response:
+        await self.rate_limiter.acquire()
+        headers = await self._get_auth_headers()
+        response = await self._client.get(path, headers=headers, params=params)
+        if response.status_code == 429:
+            raise httpx.HTTPStatusError("Rate limit", request=response.request, response=response)
+        response.raise_for_status()
+        return response
+
+    async def iter_establishments(
+        self,
+        filters: dict[str, Any],
+        page_size: int | None = None,
+        start_cursor: str | None = None,
+    ) -> AsyncIterator[tuple[list[dict[str, Any]], Optional[str]]]:
+        cursor = start_cursor or "*"
+        while cursor:
+            params = {"nombre": page_size or self.settings.sirene_default_page_size, "curseur": cursor}
+            params.update(filters)
+            try:
+                response = await self._get("/etablissements", params=params)
+            except RetryError as exc:  # pragma: no cover - safety
+                raise exc.last_attempt.exception()  # type: ignore[misc]
+            payload = response.json()
+            etablissements = payload.get("etablissements", [])
+            next_cursor = payload.get("curseurSuivant")
+            yield etablissements, next_cursor
+            if not next_cursor or next_cursor == cursor:
+                break
+            cursor = next_cursor
+
+
+class SireneImporter:
+    def __init__(self, settings: Settings | None = None) -> None:
+        self.settings = settings or get_settings()
+        self.client = SireneClient(self.settings)
+
+    async def import_for_site(self, session: Session, job: ImportJob) -> ImportJob:
+        site = session.get(Site, job.site_id)
+        if not site:
+            raise ValueError("Site introuvable")
+
+        filters = self._build_filters(site, job)
+        job.status = "running"
+        job.updated_at = datetime.utcnow()
+        session.add(job)
+        session.commit()
+        session.refresh(job)
+
+        total_imported = job.total_imported
+        total_closed = job.total_closed
+        total_errors = job.total_errors
+
+        try:
+            async for etablissements, cursor in self.client.iter_establishments(
+                filters=filters, start_cursor=job.cursor
+            ):
+                for etablissement in etablissements:
+                    try:
+                        imported, closed = self._upsert_establishment(session, site.id, etablissement)
+                        total_imported += imported
+                        total_closed += closed
+                    except Exception as exc:  # pragma: no cover - logging placeholder
+                        total_errors += 1
+                        job.last_error = str(exc)
+                session.commit()
+                job.cursor = cursor
+                job.total_imported = total_imported
+                job.total_closed = total_closed
+                job.total_errors = total_errors
+                job.updated_at = datetime.utcnow()
+                session.add(job)
+                session.commit()
+                if not cursor:
+                    break
+
+            job.status = "completed"
+            job.updated_at = datetime.utcnow()
+            session.add(job)
+            session.commit()
+            return job
+        except Exception as exc:
+            job.status = "failed"
+            job.last_error = str(exc)
+            job.updated_at = datetime.utcnow()
+            session.add(job)
+            session.commit()
+            raise
+        finally:
+            await self.client.close()
+
+    def _build_filters(self, site: Site, job: ImportJob) -> dict[str, Any]:
+        filters: dict[str, Any] = {
+            "statutDiffusion": "O",
+            "etatAdministratifEtablissement": "A,B,F",
+        }
+        sirene_filters = site.sirene_filters or {}
+        for key in ["codeNaf", "codePostalEtablissement", "codeCommuneEtablissement", "codeDepartementEtablissement"]:
+            if value := sirene_filters.get(key):
+                filters[key] = value
+        if job.naf_code:
+            filters["codeNaf"] = job.naf_code
+        if job.department:
+            filters["codeDepartementEtablissement"] = job.department
+        if job.city:
+            filters["codeCommuneEtablissement"] = job.city
+        return filters
+
+    def _upsert_establishment(self, session: Session, site_id: int, payload: dict[str, Any]) -> tuple[int, int]:
+        siret = payload.get("siret")
+        if not siret:
+            raise ValueError("SIRET manquant")
+        etablissements = payload.get("periodesEtablissement", [])
+        current = etablissements[-1] if etablissements else {}
+
+        address_parts = [
+            current.get("numeroVoieEtablissement"),
+            current.get("indiceRepetitionEtablissement"),
+            current.get("typeVoieEtablissement"),
+            current.get("libelleVoieEtablissement"),
+        ]
+        address = " ".join(str(part) for part in address_parts if part).strip() or None
+
+        db_establishment = session.exec(
+            select(Establishment).where(Establishment.siret == siret, Establishment.site_id == site_id)
+        ).one_or_none()
+
+        is_active = payload.get("etatAdministratifEtablissement", "A") == "A"
+        closure_label = None if is_active else "Définitivement fermé"
+
+        metadata = {
+            "trancheEffectifs": payload.get("trancheEffectifsEtablissement"),
+            "dateCreation": payload.get("dateCreationEtablissement"),
+        }
+
+        if db_establishment:
+            db_establishment.business_name = payload.get("uniteLegale", {}).get("denominationUniteLegale")
+            db_establishment.naf_code = payload.get("activitePrincipaleEtablissement")
+            db_establishment.naf_label = payload.get("nomenclatureActivitePrincipaleEtablissement")
+            db_establishment.address = address
+            db_establishment.postal_code = current.get("codePostalEtablissement")
+            db_establishment.city = current.get("libelleCommuneEtablissement")
+            db_establishment.department = current.get("codeDepartementEtablissement")
+            db_establishment.is_active = is_active
+            db_establishment.closure_label = closure_label
+            db_establishment.last_seen_at = datetime.utcnow()
+            db_establishment.extra_metadata = metadata
+            session.add(db_establishment)
+            imported = 0
+        else:
+            db_establishment = Establishment(
+                site_id=site_id,
+                siren=payload.get("siren"),
+                nic=payload.get("nic"),
+                siret=siret,
+                business_name=payload.get("uniteLegale", {}).get("denominationUniteLegale"),
+                naf_code=payload.get("activitePrincipaleEtablissement"),
+                naf_label=payload.get("nomenclatureActivitePrincipaleEtablissement"),
+                address=address,
+                postal_code=current.get("codePostalEtablissement"),
+                city=current.get("libelleCommuneEtablissement"),
+                department=current.get("codeDepartementEtablissement"),
+                is_active=is_active,
+                closure_label=closure_label,
+                extra_metadata=metadata,
+            )
+            session.add(db_establishment)
+            imported = 1
+
+        closed = 1 if not is_active else 0
+        return imported, closed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,26 @@
+[project]
+name = "generateur-insee-backend"
+version = "0.1.0"
+description = "Plateforme d'annuaires métiers - backend FastAPI"
+authors = [{name = "AI"}]
+requires-python = ">=3.10"
+dependencies = [
+    "fastapi>=0.110.0",
+    "uvicorn[standard]>=0.27.0",
+    "sqlmodel>=0.0.19",
+    "httpx>=0.27.0",
+    "pydantic-settings>=2.0.0",
+    "python-dotenv>=1.0.0",
+    "tenacity>=8.2.0",
+    "openai>=1.14.0"
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4",
+    "pytest-asyncio>=0.21"
+]
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Générateur d'annuaires métiers</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "generateur-insee-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.29.0",
+    "axios": "^1.6.7",
+    "leaflet": "^1.9.4",
+    "react-leaflet": "^4.2.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/leaflet": "^1.9.8",
+    "@types/react": "^18.2.15",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.2.0",
+    "typescript": "^5.4.0",
+    "vite": "^5.1.0"
+  }
+}

--- a/frontend/src/components/EstablishmentsMap.tsx
+++ b/frontend/src/components/EstablishmentsMap.tsx
@@ -1,0 +1,45 @@
+import { MapContainer, Marker, Popup, TileLayer } from "react-leaflet";
+import { useQuery } from "@tanstack/react-query";
+
+import { Establishment, api } from "../lib/api";
+
+interface Props {
+  siteId: number;
+}
+
+export function EstablishmentsMap({ siteId }: Props) {
+  const { data: establishments } = useQuery({
+    queryKey: ["establishments", siteId],
+    queryFn: async () => {
+      const { data } = await api.get<Establishment[]>(`/sites/${siteId}/establishments`);
+      return data.filter((item) => item.geo_lat && item.geo_lon);
+    },
+    refetchInterval: 5000
+  });
+
+  const center = establishments?.length
+    ? [establishments[0].geo_lat!, establishments[0].geo_lon!] as [number, number]
+    : [48.8566, 2.3522];
+
+  return (
+    <div className="card">
+      <h2>Carte des établissements</h2>
+      <MapContainer center={center} zoom={6} style={{ height: "400px", width: "100%" }}>
+        <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+        {establishments?.map((establishment) => (
+          <Marker key={establishment.id} position={[establishment.geo_lat!, establishment.geo_lon!]}>
+            <Popup>
+              <strong>{establishment.business_name || establishment.siret}</strong>
+              <br />
+              {establishment.address}
+              <br />
+              {establishment.postal_code} {establishment.city}
+              <br />
+              {establishment.is_active ? "Actif" : establishment.closure_label}
+            </Popup>
+          </Marker>
+        ))}
+      </MapContainer>
+    </div>
+  );
+}

--- a/frontend/src/components/ImportJobsManager.tsx
+++ b/frontend/src/components/ImportJobsManager.tsx
@@ -1,0 +1,75 @@
+import { FormEvent, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { ImportJob, api } from "../lib/api";
+
+interface Props {
+  siteId: number;
+}
+
+export function ImportJobsManager({ siteId }: Props) {
+  const queryClient = useQueryClient();
+  const { data: jobs } = useQuery({
+    queryKey: ["imports", siteId],
+    queryFn: async () => {
+      const { data } = await api.get<ImportJob[]>(`/sites/${siteId}/imports`);
+      return data;
+    },
+    refetchInterval: 3000
+  });
+
+  const [naf, setNaf] = useState("");
+  const [department, setDepartment] = useState("");
+  const [city, setCity] = useState("");
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const payload = {
+        naf_code: naf || undefined,
+        department: department || undefined,
+        city: city || undefined
+      };
+      const { data } = await api.post<ImportJob>(`/sites/${siteId}/imports`, payload);
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["imports", siteId] });
+      setNaf("");
+      setDepartment("");
+      setCity("");
+    }
+  });
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    mutation.mutate();
+  };
+
+  return (
+    <div className="card">
+      <h2>Import SIRENE</h2>
+      <form onSubmit={handleSubmit} className="flex-column">
+        <label>Code NAF</label>
+        <input value={naf} onChange={(e) => setNaf(e.target.value)} placeholder="ex: 4332A" />
+        <label>Département</label>
+        <input value={department} onChange={(e) => setDepartment(e.target.value)} placeholder="ex: 75" />
+        <label>Code Commune</label>
+        <input value={city} onChange={(e) => setCity(e.target.value)} placeholder="ex: 75101" />
+        <button className="btn-primary" type="submit" disabled={mutation.isPending}>
+          {mutation.isPending ? "Import en cours..." : "Lancer l'import"}
+        </button>
+      </form>
+      <div className="flex-column" style={{ marginTop: "1.5rem" }}>
+        {jobs?.map((job) => (
+          <div key={job.id}>
+            <h3>Import #{job.id}</h3>
+            <p>Statut : {job.status}</p>
+            <p>Entreprises importées : {job.total_imported}</p>
+            <p>Etablissements fermés : {job.total_closed}</p>
+            {job.last_error && <p>Erreur : {job.last_error}</p>}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ManualPagesManager.tsx
+++ b/frontend/src/components/ManualPagesManager.tsx
@@ -1,0 +1,71 @@
+import { FormEvent, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { ManualPage, api } from "../lib/api";
+
+interface Props {
+  siteId: number;
+}
+
+export function ManualPagesManager({ siteId }: Props) {
+  const queryClient = useQueryClient();
+  const { data: pages } = useQuery({
+    queryKey: ["pages", siteId],
+    queryFn: async () => {
+      const { data } = await api.get<ManualPage[]>(`/sites/${siteId}/pages`);
+      return data;
+    }
+  });
+
+  const [title, setTitle] = useState("");
+  const [slug, setSlug] = useState("");
+  const [content, setContent] = useState("");
+  const [seoDescription, setSeoDescription] = useState("");
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const payload = { title, slug, content, seo_description: seoDescription };
+      const { data } = await api.post<ManualPage>(`/sites/${siteId}/pages`, payload);
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["pages", siteId] });
+      setTitle("");
+      setSlug("");
+      setContent("");
+      setSeoDescription("");
+    }
+  });
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    mutation.mutate();
+  };
+
+  return (
+    <div className="card">
+      <h2>Pages manuelles</h2>
+      <form onSubmit={handleSubmit} className="flex-column">
+        <label>Titre</label>
+        <input value={title} onChange={(e) => setTitle(e.target.value)} required />
+        <label>Slug</label>
+        <input value={slug} onChange={(e) => setSlug(e.target.value)} required />
+        <label>Contenu</label>
+        <textarea value={content} onChange={(e) => setContent(e.target.value)} rows={6} required />
+        <label>Description SEO</label>
+        <textarea value={seoDescription} onChange={(e) => setSeoDescription(e.target.value)} rows={3} />
+        <button className="btn-primary" type="submit" disabled={mutation.isPending}>
+          {mutation.isPending ? "Enregistrement..." : "Ajouter"}
+        </button>
+      </form>
+      <div className="flex-column" style={{ marginTop: "1.5rem" }}>
+        {pages?.map((page) => (
+          <div key={page.id}>
+            <h3>{page.title}</h3>
+            <p>{page.seo_description}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/PromptManager.tsx
+++ b/frontend/src/components/PromptManager.tsx
@@ -1,0 +1,133 @@
+import { FormEvent, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { GenerationResponse, PromptTemplate, api } from "../lib/api";
+
+interface Props {
+  siteId: number;
+}
+
+export function PromptManager({ siteId }: Props) {
+  const queryClient = useQueryClient();
+  const { data: prompts } = useQuery({
+    queryKey: ["prompts", siteId],
+    queryFn: async () => {
+      const { data } = await api.get<PromptTemplate[]>(`/sites/${siteId}/prompts`);
+      return data;
+    }
+  });
+
+  const [label, setLabel] = useState("");
+  const [prompt, setPrompt] = useState("");
+  const [scope, setScope] = useState("city");
+  const [selectedPrompt, setSelectedPrompt] = useState<number | undefined>();
+  const [variables, setVariables] = useState("{\"ville\": \"Paris\"}");
+  const [result, setResult] = useState<GenerationResponse | null>(null);
+
+  const createMutation = useMutation({
+    mutationFn: async () => {
+      const payload = { label, prompt, scope };
+      const { data } = await api.post<PromptTemplate>(`/sites/${siteId}/prompts`, payload);
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["prompts", siteId] });
+      setLabel("");
+      setPrompt("");
+      setScope("city");
+    }
+  });
+
+  const generateMutation = useMutation({
+    mutationFn: async () => {
+      if (!selectedPrompt) {
+        throw new Error("Sélectionnez un prompt");
+      }
+      let variablesObject: Record<string, string>;
+      try {
+        variablesObject = JSON.parse(variables);
+      } catch (error) {
+        throw new Error("Variables JSON invalides");
+      }
+      const { data } = await api.post<GenerationResponse>(`/sites/${siteId}/generate`, {
+        template_id: selectedPrompt,
+        variables: variablesObject
+      });
+      return data;
+    },
+    onSuccess: (data) => {
+      setResult(data);
+    }
+  });
+
+  const handleCreate = (event: FormEvent) => {
+    event.preventDefault();
+    createMutation.mutate();
+  };
+
+  const handleGenerate = (event: FormEvent) => {
+    event.preventDefault();
+    generateMutation.mutate();
+  };
+
+  return (
+    <div className="card">
+      <h2>Prompts OpenAI</h2>
+      <form onSubmit={handleCreate} className="flex-column">
+        <label>Libellé</label>
+        <input value={label} onChange={(e) => setLabel(e.target.value)} required />
+        <label>Scope</label>
+        <select value={scope} onChange={(e) => setScope(e.target.value)}>
+          <option value="city">Ville</option>
+          <option value="postal_code">Code postal</option>
+          <option value="custom">Personnalisé</option>
+        </select>
+        <label>Prompt</label>
+        <textarea
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          rows={4}
+          placeholder="Ex: Rédige une introduction pour {ville}"
+          required
+        />
+        <button className="btn-primary" type="submit" disabled={createMutation.isPending}>
+          {createMutation.isPending ? "Enregistrement..." : "Ajouter"}
+        </button>
+      </form>
+
+      <div style={{ marginTop: "1.5rem" }}>
+        <h3>Tester un prompt</h3>
+        <form onSubmit={handleGenerate} className="flex-column">
+          <label>Prompt à tester</label>
+          <select
+            value={selectedPrompt ?? ""}
+            onChange={(e) => setSelectedPrompt(Number(e.target.value))}
+            required
+          >
+            <option value="" disabled>
+              Choisir un prompt
+            </option>
+            {prompts?.map((item) => (
+              <option key={item.id} value={item.id}>
+                {item.label}
+              </option>
+            ))}
+          </select>
+          <label>Variables (JSON)</label>
+          <textarea value={variables} onChange={(e) => setVariables(e.target.value)} rows={4} />
+          <button className="btn-secondary" type="submit" disabled={generateMutation.isPending}>
+            {generateMutation.isPending ? "Génération..." : "Générer"}
+          </button>
+        </form>
+        {result && (
+          <div className="card" style={{ marginTop: "1rem" }}>
+            <h4>Prompt envoyé</h4>
+            <pre>{result.prompt}</pre>
+            <h4>Contenu généré</h4>
+            <p>{result.content}</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/SiteDetails.tsx
+++ b/frontend/src/components/SiteDetails.tsx
@@ -1,0 +1,38 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { Site, api } from "../lib/api";
+import { EstablishmentsMap } from "./EstablishmentsMap";
+import { ImportJobsManager } from "./ImportJobsManager";
+import { ManualPagesManager } from "./ManualPagesManager";
+import { PromptManager } from "./PromptManager";
+
+interface Props {
+  site: Site;
+}
+
+export function SiteDetails({ site }: Props) {
+  const { data: siteData } = useQuery({
+    queryKey: ["site", site.id],
+    queryFn: async () => {
+      const { data } = await api.get<Site>(`/sites/${site.id}`);
+      return data;
+    },
+    initialData: site
+  });
+
+  return (
+    <div className="flex-column">
+      <div className="card">
+        <h1>{siteData?.name}</h1>
+        <p>{siteData?.description}</p>
+        <p>
+          Slug : <strong>{siteData?.slug}</strong>
+        </p>
+      </div>
+      <ImportJobsManager siteId={site.id} />
+      <ManualPagesManager siteId={site.id} />
+      <PromptManager siteId={site.id} />
+      <EstablishmentsMap siteId={site.id} />
+    </div>
+  );
+}

--- a/frontend/src/components/SiteForm.tsx
+++ b/frontend/src/components/SiteForm.tsx
@@ -1,0 +1,66 @@
+import { FormEvent, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { Site, api } from "../lib/api";
+
+interface Props {
+  onCreated?: (site: Site) => void;
+}
+
+export function SiteForm({ onCreated }: Props) {
+  const queryClient = useQueryClient();
+  const [name, setName] = useState("");
+  const [slug, setSlug] = useState("");
+  const [description, setDescription] = useState("");
+  const [naf, setNaf] = useState("");
+  const [department, setDepartment] = useState("");
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const payload = {
+        name,
+        slug,
+        description,
+        sirene_filters: {
+          codeNaf: naf || undefined,
+          codeDepartementEtablissement: department || undefined
+        }
+      };
+      const { data } = await api.post<Site>("/sites", payload);
+      return data;
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ["sites"] });
+      setName("");
+      setSlug("");
+      setDescription("");
+      setNaf("");
+      setDepartment("");
+      onCreated?.(data);
+    }
+  });
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    mutation.mutate();
+  };
+
+  return (
+    <form className="card" onSubmit={handleSubmit}>
+      <h2>Créer un annuaire</h2>
+      <label>Nom du site</label>
+      <input value={name} onChange={(e) => setName(e.target.value)} required />
+      <label>Slug</label>
+      <input value={slug} onChange={(e) => setSlug(e.target.value)} required />
+      <label>Description</label>
+      <textarea value={description} onChange={(e) => setDescription(e.target.value)} />
+      <label>Code NAF (filtre)</label>
+      <input value={naf} onChange={(e) => setNaf(e.target.value)} placeholder="ex: 4332A" />
+      <label>Département</label>
+      <input value={department} onChange={(e) => setDepartment(e.target.value)} placeholder="ex: 75" />
+      <button className="btn-primary" type="submit" disabled={mutation.isPending}>
+        {mutation.isPending ? "Création..." : "Créer"}
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/components/SiteList.tsx
+++ b/frontend/src/components/SiteList.tsx
@@ -1,0 +1,36 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { Site, api } from "../lib/api";
+
+interface Props {
+  onSelect: (site: Site) => void;
+  selectedSiteId?: number;
+}
+
+export function SiteList({ onSelect, selectedSiteId }: Props) {
+  const { data: sites } = useQuery({
+    queryKey: ["sites"],
+    queryFn: async () => {
+      const { data } = await api.get<Site[]>("/sites");
+      return data;
+    }
+  });
+
+  return (
+    <div className="card">
+      <h2>Annuaires existants</h2>
+      <div className="flex-column">
+        {sites?.map((site) => (
+          <button
+            key={site.id}
+            className={site.id === selectedSiteId ? "btn-primary" : "btn-secondary"}
+            onClick={() => onSelect(site)}
+          >
+            {site.name}
+          </button>
+        ))}
+        {(!sites || sites.length === 0) && <p>Aucun site pour le moment.</p>}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,76 @@
+import axios from "axios";
+
+export const api = axios.create({
+  baseURL: "/api"
+});
+
+export interface Site {
+  id: number;
+  name: string;
+  slug: string;
+  description?: string;
+  sirene_filters?: Record<string, string>;
+  openai_prompt?: string;
+  created_at: string;
+}
+
+export interface ManualPage {
+  id: number;
+  site_id: number;
+  title: string;
+  slug: string;
+  content: string;
+  seo_description?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Establishment {
+  id: number;
+  site_id: number;
+  siren: string;
+  nic: string;
+  siret: string;
+  business_name?: string;
+  naf_code?: string;
+  naf_label?: string;
+  address?: string;
+  postal_code?: string;
+  city?: string;
+  department?: string;
+  is_active: boolean;
+  closure_label?: string;
+  geo_lat?: number;
+  geo_lon?: number;
+  geo_status?: string;
+}
+
+export interface ImportJob {
+  id: number;
+  site_id: number;
+  naf_code?: string;
+  department?: string;
+  city?: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+  cursor?: string;
+  total_imported: number;
+  total_closed: number;
+  total_errors: number;
+  last_error?: string;
+}
+
+export interface PromptTemplate {
+  id: number;
+  site_id: number;
+  label: string;
+  prompt: string;
+  scope: string;
+  created_at: string;
+}
+
+export interface GenerationResponse {
+  prompt: string;
+  content: string;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import L from "leaflet";
+
+import App from "./pages/App";
+import "leaflet/dist/leaflet.css";
+import "./styles.css";
+
+import markerIcon2x from "leaflet/dist/images/marker-icon-2x.png";
+import markerIcon from "leaflet/dist/images/marker-icon.png";
+import markerShadow from "leaflet/dist/images/marker-shadow.png";
+
+// Fix Leaflet marker assets when bundled via Vite
+delete (L.Icon.Default.prototype as unknown as { _getIconUrl: unknown })._getIconUrl;
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: markerIcon2x,
+  iconUrl: markerIcon,
+  shadowUrl: markerShadow
+});
+
+const queryClient = new QueryClient();
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  </React.StrictMode>
+);

--- a/frontend/src/pages/App.tsx
+++ b/frontend/src/pages/App.tsx
@@ -1,0 +1,35 @@
+import { useState } from "react";
+
+import { Site } from "../lib/api";
+import { SiteDetails } from "../components/SiteDetails";
+import { SiteForm } from "../components/SiteForm";
+import { SiteList } from "../components/SiteList";
+
+export default function App() {
+  const [selectedSite, setSelectedSite] = useState<Site | null>(null);
+
+  return (
+    <div className="container">
+      <h1>Générateur d'annuaires métiers</h1>
+      <p>
+        Configurez vos annuaires métiers, importez les données SIRENE, géocodez les établissements et
+        gérez vos pages personnalisées.
+      </p>
+      <div className="flex">
+        <div style={{ flex: 1 }}>
+          <SiteForm onCreated={setSelectedSite} />
+          <SiteList onSelect={setSelectedSite} selectedSiteId={selectedSite?.id} />
+        </div>
+        <div style={{ flex: 2 }}>
+          {selectedSite ? (
+            <SiteDetails site={selectedSite} />
+          ) : (
+            <div className="card">
+              <p>Sélectionnez un site pour afficher ses détails.</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,78 @@
+:root {
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #1f2933;
+  background-color: #f8fafc;
+}
+
+body {
+  margin: 0;
+  background-color: #f8fafc;
+}
+
+a {
+  color: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1.5rem;
+}
+
+.card {
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+input,
+textarea,
+select {
+  width: 100%;
+  padding: 0.75rem;
+  margin-bottom: 1rem;
+  border-radius: 8px;
+  border: 1px solid #cbd5e1;
+  background-color: #f9fafb;
+}
+
+label {
+  font-weight: 600;
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.btn-primary {
+  background-color: #2563eb;
+  border: none;
+  padding: 0.75rem 1.25rem;
+  border-radius: 8px;
+  color: white;
+  font-weight: 600;
+}
+
+.btn-secondary {
+  background-color: #f1f5f9;
+  border: none;
+  padding: 0.75rem 1.25rem;
+  border-radius: 8px;
+  color: #1f2937;
+  font-weight: 600;
+}
+
+.flex {
+  display: flex;
+  gap: 1rem;
+}
+
+.flex-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="vite/client" />
+
+declare module "*.png" {
+  const src: string;
+  export default src;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      "/api": {
+        target: "http://localhost:8000",
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, "")
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a FastAPI backend with SQLModel storage, SIRENE importer, BAN geocoding, and OpenAI-driven content templates
- add REST endpoints for sites, manual pages, imports, establishments, and prompt management with rate limiting and cursor support
- create a React + Vite admin console for configuring sites, launching imports, managing prompts/pages, and visualising establishments on a Leaflet map
- document local setup for both backend and frontend along with project dependencies

## Testing
- `python -m compileall app`

------
https://chatgpt.com/codex/tasks/task_e_68dcac11f490833186ad9c9da8cdd0ac